### PR TITLE
Tanh normal properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tensorcontainer"
-version = "0.6.1"
+version = "0.6.2"
 description = "TensorDict-like functionality for PyTorch with PyTree compatibility and torch.compile support"
 authors = [{name="Tim Joseph", email="tim@mctigger.com"}]
 license = {text = "MIT"}

--- a/src/tensorcontainer/distributions/sampling.py
+++ b/src/tensorcontainer/distributions/sampling.py
@@ -1,50 +1,135 @@
 import torch
-from torch.distributions import Distribution
+from torch.distributions import Distribution, constraints
+from functools import cached_property
+from typing import Any, Optional
 
 
 class SamplingDistribution(Distribution):
-    def __init__(self, base_distribution: Distribution, n=100):
+    """
+    A wrapper for a PyTorch distribution that calculates statistics via sampling.
+
+    This distribution is useful when the analytical statistics of a base
+    distribution are not available or not desired. Instead, it computes
+    properties like mean, stddev, variance, and mode by drawing samples from the
+    base distribution.
+
+    To improve efficiency, it caches the generated samples and the computed
+    statistics, ensuring that repeated access to these properties does not
+    trigger redundant computations.
+
+    Args:
+        base_distribution (Distribution): The underlying distribution to sample from.
+        n (int, optional): The number of samples to draw for calculating
+            statistics. Defaults to 100.
+    """
+
+    __slots__ = ["base_dist", "n"]
+
+    def __init__(self, base_distribution: Distribution, *, n: int = 100):
+        if not isinstance(base_distribution, Distribution):
+            raise TypeError(
+                "base_distribution must be a torch.distributions.Distribution"
+            )
+        if not isinstance(n, int) or n <= 0:
+            raise ValueError("n must be a positive integer")
+
         self.base_dist = base_distribution
         self.n = n
 
-    def __getattr__(self, name):
+        super().__init__(
+            batch_shape=self.base_dist.batch_shape,
+            event_shape=self.base_dist.event_shape,
+            validate_args=False,  # We defer validation to the base distribution
+        )
+
+    def __repr__(self) -> str:
+        return f"SamplingDistribution(base_dist={self.base_dist}, n={self.n})"
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegates attribute access to the base distribution."""
         return getattr(self.base_dist, name)
 
-    @property
-    def has_rsample(self):
-        return self.base_dist.has_rsample
+    @cached_property
+    def _samples(self) -> torch.Tensor:
+        """
+        Cached samples from the base distribution.
 
-    def rsample(self, sample_shape=torch.Size()):
-        return self.base_dist.rsample(sample_shape)
-
-    def sample(self, sample_shape=torch.Size()):
+        Uses rsample if available for reparameterization-friendly gradients,
+        otherwise falls back to sample.
+        """
+        sample_shape = torch.Size((self.n,))
+        if self.base_dist.has_rsample:
+            return self.base_dist.rsample(sample_shape)
         return self.base_dist.sample(sample_shape)
 
     @property
-    def mean(self):
-        return self.base_dist.rsample((self.n,)).mean(0)
+    def has_rsample(self) -> bool:
+        return self.base_dist.has_rsample
 
-    @property
-    def stddev(self):
-        return self.base_dist.rsample((self.n,)).std(0)
+    def rsample(self, sample_shape: Any = torch.Size()) -> torch.Tensor:
+        """Delegates rsample to the base distribution."""
+        return self.base_dist.rsample(sample_shape)
 
-    @property
-    def variance(self):
-        return self.base_dist.rsample((self.n,)).var(0)
+    def sample(self, sample_shape: Any = torch.Size()) -> torch.Tensor:
+        """Delegates sample to the base distribution."""
+        return self.base_dist.sample(sample_shape)
 
-    @property
-    def mode(self):
-        samples = self.base_dist.sample((self.n,))
-        log_probs = self.base_dist.log_prob(samples).view(self.n, -1)
-        index = torch.argmax(log_probs, dim=0)
+    @cached_property
+    def mean(self) -> torch.Tensor:  # type: ignore
+        """Mean of the distribution, computed as the mean of cached samples."""
+        return self._samples.float().mean(0)
 
-        selected = torch.gather(samples.view(self.n, -1), 0, index.unsqueeze(0))
-        return selected
+    @cached_property
+    def stddev(self) -> torch.Tensor:  # type: ignore
+        """Standard deviation of the distribution, computed from cached samples."""
+        return self._samples.float().std(0)
 
-    def entropy(self):
-        samples = self.base_dist.rsample((self.n,))
-        logprob = self.base_dist.log_prob(samples)
-        return -logprob.mean(0)
+    @cached_property
+    def variance(self) -> torch.Tensor:  # type: ignore
+        """Variance of the distribution, computed from cached samples."""
+        return self._samples.float().var(0)
 
-    def log_prob(self, value):
+    @cached_property
+    def mode(self) -> torch.Tensor:  # type: ignore
+        """
+        Mode of the distribution.
+
+        Tries to return the analytical mode if available. Otherwise, it computes
+        the mode via Monte Carlo approximation by finding the sample with the
+        highest log probability.
+        """
+        try:
+            return self.base_dist.mode
+        except (AttributeError, NotImplementedError):
+            pass  # Fall back to sampling
+
+        log_probs = self.base_dist.log_prob(self._samples)
+        max_indices = torch.argmax(log_probs, dim=0)
+
+        # Use advanced indexing to gather the modes efficiently
+        return self._samples.gather(
+            0, max_indices.reshape(1, *max_indices.shape, *(1,) * len(self.event_shape))
+        ).squeeze(0)
+
+    def entropy(self) -> torch.Tensor:
+        """
+        Entropy of the distribution, estimated via Monte Carlo.
+
+        Calculates the negative mean of the log probabilities of cached samples.
+        """
+        log_prob = self.base_dist.log_prob(self._samples)
+        return -log_prob.mean(0)
+
+    def log_prob(self, value: torch.Tensor) -> torch.Tensor:
+        """Delegates log probability calculation to the base distribution."""
         return self.base_dist.log_prob(value)
+
+    @property
+    def support(self) -> Optional[constraints.Constraint]:
+        """Delegates support to the base distribution."""
+        return self.base_dist.support
+
+    @property
+    def arg_constraints(self) -> dict:
+        """Delegates argument constraints to the base distribution."""
+        return self.base_dist.arg_constraints

--- a/src/tensorcontainer/tensor_distribution/independent.py
+++ b/src/tensorcontainer/tensor_distribution/independent.py
@@ -19,7 +19,11 @@ class TensorIndependent(TensorDistribution):
         self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
 
         super().__init__(
-            Size(base_distribution.shape[:-reinterpreted_batch_ndims]),
+            Size(
+                base_distribution.shape[:-reinterpreted_batch_ndims]
+                if reinterpreted_batch_ndims > 0
+                else base_distribution.shape
+            ),
             base_distribution.device,
         )
 

--- a/tests/tensor_distribution/test_independent.py
+++ b/tests/tensor_distribution/test_independent.py
@@ -41,7 +41,7 @@ class TestTensorIndependentInitialization:
         )
         assert td_independent.batch_shape == expected_batch_shape
         assert td_independent.dist().batch_shape == expected_batch_shape
-        
+
         # Test that shape property matches expected_batch_shape (fixes bug with reinterpreted_batch_ndims=0)
         assert td_independent.shape == expected_batch_shape
 

--- a/tests/tensor_distribution/test_independent.py
+++ b/tests/tensor_distribution/test_independent.py
@@ -41,6 +41,9 @@ class TestTensorIndependentInitialization:
         )
         assert td_independent.batch_shape == expected_batch_shape
         assert td_independent.dist().batch_shape == expected_batch_shape
+        
+        # Test that shape property matches expected_batch_shape (fixes bug with reinterpreted_batch_ndims=0)
+        assert td_independent.shape == expected_batch_shape
 
 
 class TestTensorIndependentTensorContainerIntegration:

--- a/tests/tensor_distribution/test_sampling.py
+++ b/tests/tensor_distribution/test_sampling.py
@@ -1,0 +1,171 @@
+import pytest
+import torch
+from torch.distributions import Normal, Categorical
+
+from tensorcontainer.distributions.sampling import SamplingDistribution
+
+
+class TestSamplingDistribution:
+    def test_initialization(self):
+        base_dist = Normal(0, 1)
+        dist = SamplingDistribution(base_dist, n=50)
+        assert dist.n == 50
+        assert dist.base_dist is base_dist
+
+        with pytest.raises(TypeError):
+            SamplingDistribution("not a distribution")  # type: ignore
+
+        with pytest.raises(ValueError):
+            SamplingDistribution(base_dist, n=0)
+
+        with pytest.raises(ValueError):
+            SamplingDistribution(base_dist, n=-10)
+
+    def test_repr(self):
+        base_dist = Normal(0, 1)
+        dist = SamplingDistribution(base_dist, n=50)
+        assert repr(dist) == f"SamplingDistribution(base_dist={base_dist}, n=50)"
+
+    def test_sampling_methods(self):
+        base_dist = Normal(torch.zeros(2), torch.ones(2))
+        dist = SamplingDistribution(base_dist, n=100)
+
+        # Test sample
+        sample = dist.sample(torch.Size((dist.n,)))
+        # The shape should be (n, *base_dist.event_shape)
+        assert (
+            sample.shape
+            == torch.Size((dist.n,)) + base_dist.batch_shape + base_dist.event_shape
+        )
+
+        # Test rsample
+        rsample = dist.rsample(torch.Size((dist.n,)))
+        assert (
+            rsample.shape
+            == torch.Size((dist.n,)) + base_dist.batch_shape + base_dist.event_shape
+        )
+        # rsample should have grad if base dist params have grad
+        base_dist.loc = base_dist.loc.clone().requires_grad_()
+        # Clear the cache to re-sample with the new grad requirements
+        if hasattr(dist, "_samples"):
+            del dist._samples
+        rsample = dist.rsample(torch.Size((dist.n,)))
+        assert rsample.requires_grad
+
+
+class TestSamplingPropertiesRsample:
+    def test_cached_properties_with_rsample(self):
+        base_dist = Normal(torch.tensor([0.0, 10.0]), torch.tensor([1.0, 0.1]))
+        dist = SamplingDistribution(base_dist, n=10000)
+
+        # Accessing properties should cache them
+        mean1 = dist.mean
+        mean2 = dist.mean
+        assert torch.all(mean1 == mean2)
+        assert dist._samples is dist._samples  # check if samples are cached
+
+        # Check if stats are reasonable
+        assert torch.allclose(dist.mean, base_dist.mean, atol=0.1)
+        assert torch.allclose(dist.stddev, base_dist.stddev, atol=0.1)
+        assert torch.allclose(dist.variance, base_dist.variance, atol=0.2)
+
+        # Check caching
+        samples_id = id(dist._samples)
+        _ = dist.stddev
+        assert id(dist._samples) == samples_id
+        _ = dist.variance
+        assert id(dist._samples) == samples_id
+
+    def test_mode_sampling(self):
+        # Use a distribution where mode is not analytical to test sampling-based mode
+        base_dist = Normal(torch.tensor([0.0, 10.0]), torch.tensor([1.0, 2.0]))
+
+        # Mock analytical mode to be unavailable
+        class MockNormal(Normal):
+            @property
+            def mode(self):
+                raise NotImplementedError
+
+        mock_dist = MockNormal(base_dist.loc, base_dist.scale)
+        dist = SamplingDistribution(mock_dist, n=1000)
+
+        mode = dist.mode
+        assert mode.shape == base_dist.batch_shape
+        # The sampled mode should be close to the analytical mode
+        assert torch.allclose(mode, mock_dist.loc, atol=0.5)
+
+        # Check caching
+        mode2 = dist.mode
+        assert torch.all(mode == mode2)
+
+    def test_entropy_sampling(self):
+        base_dist = Normal(0, 1)
+        dist = SamplingDistribution(base_dist, n=10000)
+
+        # Sampled entropy should be close to analytical entropy
+        analytical_entropy = base_dist.entropy()
+        sampled_entropy = dist.entropy()
+        assert torch.allclose(analytical_entropy, sampled_entropy, atol=0.1)
+
+        # Check caching of samples
+        samples_id = id(dist._samples)
+        _ = dist.entropy()
+        assert id(dist._samples) == samples_id
+
+
+class TestSamplingPropertiesNoRsample:
+    def test_cached_properties_without_rsample(self):
+        # Categorical does not have rsample
+        base_dist = Categorical(torch.tensor([0.1, 0.2, 0.7]))
+        dist = SamplingDistribution(base_dist, n=10000)
+
+        # Accessing properties should cache them
+        mean1 = dist.mean
+        mean2 = dist.mean
+        assert torch.all(mean1 == mean2)
+        assert dist._samples is dist._samples
+
+        # Check if stats are reasonable for categorical
+        # mean of samples should be close to E[X] = sum(i * p_i)
+        expected_mean = torch.tensor(0 * 0.1 + 1 * 0.2 + 2 * 0.7)
+        assert torch.allclose(dist.mean.float(), expected_mean, atol=0.1)
+
+
+class TestSamplingWithIndependent:
+    def test_sampling_with_independent_normal(self):
+        # Test with Independent(Normal) as base_dist
+        # Corrected reinterpreted_batch_ndims to 0 as Normal(0,1) has no batch dimensions to reinterpret
+        base_dist = torch.distributions.Independent(Normal(0, 1), 0)
+        dist = SamplingDistribution(base_dist, n=1000)
+
+        sample = dist.sample((1000,))
+        # The shape should be (n, *base_dist.event_shape)
+        assert sample.shape == (1000, *base_dist.event_shape)
+
+        # Check if samples are within the expected range for Normal(0,1)
+        # Check if the mean and stddev of samples are close to the analytical values
+        assert torch.allclose(sample.mean(), torch.tensor(0.0), atol=0.1)
+        assert torch.allclose(sample.std(), torch.tensor(1.0), atol=0.1)
+
+    def test_log_prob_with_independent_normal(self):
+        # Test log_prob with Independent(Normal) as base_dist
+        base_dist = torch.distributions.Independent(
+            Normal(torch.tensor([0.0, 10.0]), torch.tensor([1.0, 2.0])), 1
+        )
+        dist = SamplingDistribution(base_dist, n=10000)
+
+        # Sampled log_prob should be close to analytical log_prob
+        # For Independent(Normal(loc, scale), 1), log_prob is sum of log_prob of each element
+        # For a single element Normal(loc, scale), log_prob is -0.5 * ((x - loc) / scale)**2 - 0.5 * log(2 * pi * scale**2)
+        # For Independent(Normal(loc, scale), 1), the event_shape is (1,)
+        # The log_prob of the sampled value should be close to the log_prob of the base distribution
+        samples = dist.sample(torch.Size((1,)))
+        sampled_log_prob = dist.log_prob(samples)
+        analytical_log_prob = base_dist.log_prob(samples)
+
+        assert torch.allclose(sampled_log_prob, analytical_log_prob, atol=0.1)
+
+        # Check caching of samples for log_prob
+        samples_id = id(dist._samples)
+        _ = dist.log_prob(samples)
+        assert id(dist._samples) == samples_id

--- a/tests/tensor_distribution/test_tanh_normal.py
+++ b/tests/tensor_distribution/test_tanh_normal.py
@@ -29,13 +29,15 @@ class TestTensorTanhNormal:
 
     def test_initialization_reinterpreted_batch_ndims(self):
         # Test with TensorIndependent wrapper for reinterpreted batch dimensions
-        from src.tensorcontainer.tensor_distribution.independent import TensorIndependent
-        
+        from src.tensorcontainer.tensor_distribution.independent import (
+            TensorIndependent,
+        )
+
         loc = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
         scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         base_dist = TensorTanhNormal(loc, scale)
         dist = TensorIndependent(base_dist, reinterpreted_batch_ndims=1)
-        
+
         assert torch.equal(base_dist.loc, loc)
         assert torch.equal(base_dist.scale, scale)
         assert base_dist.shape == loc.shape

--- a/tests/tensor_distribution/test_tanh_normal.py
+++ b/tests/tensor_distribution/test_tanh_normal.py
@@ -1,15 +1,13 @@
 import torch
-from torch.distributions import Normal, TransformedDistribution
 
 from src.tensorcontainer.tensor_distribution.tanh_normal import (
-    ClampedTanhTransform,
     TensorTanhNormal,
 )
 from tests.compile_utils import run_and_compare_compiled
 
 
 class TestTensorTanhNormal:
-    def test_initialization(self):
+    def test_initialization_scalar(self):
         # Test with scalar loc and scale
         loc = torch.tensor(0.0)
         scale = torch.tensor(1.0)
@@ -19,6 +17,7 @@ class TestTensorTanhNormal:
         assert dist.shape == torch.Size([])
         assert dist.device == loc.device
 
+    def test_initialization_tensor(self):
         # Test with tensor loc and scale
         loc = torch.tensor([0.0, 1.0])
         scale = torch.tensor([1.0, 2.0])
@@ -28,44 +27,50 @@ class TestTensorTanhNormal:
         assert dist.shape == loc.shape
         assert dist.device == loc.device
 
-        # Test with reinterpreted_batch_ndims
+    def test_initialization_reinterpreted_batch_ndims(self):
+        # Test with TensorIndependent wrapper for reinterpreted batch dimensions
+        from src.tensorcontainer.tensor_distribution.independent import TensorIndependent
+        
         loc = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
         scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        dist = TensorTanhNormal(loc, scale, reinterpreted_batch_ndims=1)
-        assert torch.equal(dist.loc, loc)
-        assert torch.equal(dist.scale, scale)
-        assert dist.shape == loc.shape
-        assert dist.device == loc.device
-        assert dist._reinterpreted_batch_ndims == 1
+        base_dist = TensorTanhNormal(loc, scale)
+        dist = TensorIndependent(base_dist, reinterpreted_batch_ndims=1)
+        
+        assert torch.equal(base_dist.loc, loc)
+        assert torch.equal(base_dist.scale, scale)
+        assert base_dist.shape == loc.shape
+        assert base_dist.device == loc.device
+        assert dist.reinterpreted_batch_ndims == 1
 
-    def test_rsample_and_log_prob(self):
+    def test_rsample(self):
         loc = torch.tensor([0.0, 1.0])
         scale = torch.tensor([1.0, 0.5])
         tensor_dist = TensorTanhNormal(loc, scale)
-
-        # Create a reference torch.distributions.TransformedDistribution
-        base_normal = Normal(loc, scale)
-        reference_dist_base = TransformedDistribution(
-            base_normal, ClampedTanhTransform()
-        )
-
-        # Wrap the reference distribution in Independent to match TensorTanhNormal's behavior
-        reference_dist = torch.distributions.Independent(reference_dist_base, 1)
 
         sample_shape = torch.Size((100,))
         samples = tensor_dist.rsample(sample_shape)
         assert samples.shape == sample_shape + loc.shape
 
+    def test_log_prob(self):
+        loc = torch.tensor([0.0, 1.0])
+        scale = torch.tensor([1.0, 0.5])
+        tensor_dist = TensorTanhNormal(loc, scale)
+
+        sample_shape = torch.Size((100,))
+        samples = tensor_dist.rsample(sample_shape)
+
         # Check log_prob
+        # Use the same samples for both log_prob calculations
         log_probs = tensor_dist.log_prob(samples)
+
+        # The log_prob of the TensorTanhNormal should be equivalent to the log_prob
+        # of the underlying TransformedDistribution.
+        reference_dist = tensor_dist.dist()
         reference_log_probs = reference_dist.log_prob(samples)
+
         assert torch.allclose(log_probs, reference_log_probs, atol=1e-5)
 
-        # Check mean (approximate for rsample)
-        # This is a sanity check, not a strict equality
-        # Removed: TransformedDistribution does not implement .mean
-
-    def test_compile_compatibility(self):
+    def test_compile_compatibility_rsample(self):
         loc = torch.tensor([0.0, 1.0])
         scale = torch.tensor([1.0, 0.5])
         dist = TensorTanhNormal(loc, scale)
@@ -73,6 +78,79 @@ class TestTensorTanhNormal:
         # Test rsample
         run_and_compare_compiled(dist.rsample, torch.Size((5,)))
 
+    def test_compile_compatibility_log_prob(self):
+        loc = torch.tensor([0.0, 1.0])
+        scale = torch.tensor([1.0, 0.5])
+        dist = TensorTanhNormal(loc, scale)
+
         # Test log_prob
         value = dist.rsample(torch.Size((1,)))
         run_and_compare_compiled(dist.log_prob, value)
+
+    def test_property_types(self):
+        """Test that properties exist and return tensors."""
+        loc = torch.tensor([0.0, 1.0])
+        scale = torch.tensor([1.0, 0.5])
+        dist = TensorTanhNormal(loc, scale)
+
+        # Test that properties exist and return tensors
+        assert isinstance(dist.loc, torch.Tensor)
+        assert isinstance(dist.scale, torch.Tensor)
+        assert isinstance(dist.mean, torch.Tensor)
+        assert isinstance(dist.variance, torch.Tensor)
+        assert isinstance(dist.stddev, torch.Tensor)
+
+    def test_basic_property_values(self):
+        """Test basic property values match input parameters."""
+        loc = torch.tensor([0.0, 1.0])
+        scale = torch.tensor([1.0, 0.5])
+        dist = TensorTanhNormal(loc, scale)
+
+        # Test basic property values
+        assert torch.equal(dist.loc, loc)
+        assert torch.equal(dist.scale, scale)
+
+    def test_mean_range_validation(self):
+        """Test that mean is in the valid range (-1, 1) for tanh distribution."""
+        loc = torch.tensor([0.0, 1.0])
+        scale = torch.tensor([1.0, 0.5])
+        dist = TensorTanhNormal(loc, scale)
+
+        # Test that mean is in the valid range (-1, 1) for tanh distribution
+        assert torch.all(dist.mean >= -1.0) and torch.all(dist.mean <= 1.0)
+
+    def test_variance_and_stddev_properties(self):
+        """Test variance and stddev properties."""
+        loc = torch.tensor([0.0, 1.0])
+        scale = torch.tensor([1.0, 0.5])
+        dist = TensorTanhNormal(loc, scale)
+
+        # Test that variance and stddev are positive
+        assert torch.all(dist.variance >= 0.0)
+        assert torch.all(dist.stddev >= 0.0)
+
+        # Test that stddev is square root of variance
+        assert torch.allclose(dist.stddev, torch.sqrt(dist.variance), atol=1e-6)
+
+    def test_property_shapes_scalar(self):
+        """Test that properties have correct shapes for scalar case."""
+        # Test scalar case
+        loc_scalar = torch.tensor(0.0)
+        scale_scalar = torch.tensor(1.0)
+        dist_scalar = TensorTanhNormal(loc_scalar, scale_scalar)
+
+        assert dist_scalar.mean.shape == torch.Size([])
+        assert dist_scalar.variance.shape == torch.Size([])
+        assert dist_scalar.stddev.shape == torch.Size([])
+
+    def test_property_shapes_tensor(self):
+        """Test that properties have correct shapes for tensor case."""
+        # Test tensor case
+        loc_tensor = torch.tensor([0.0, 1.0, -0.5])
+        scale_tensor = torch.tensor([1.0, 0.5, 2.0])
+        dist_tensor = TensorTanhNormal(loc_tensor, scale_tensor)
+
+        expected_shape = loc_tensor.shape
+        assert dist_tensor.mean.shape == expected_shape
+        assert dist_tensor.variance.shape == expected_shape
+        assert dist_tensor.stddev.shape == expected_shape


### PR DESCRIPTION
Pull Request Summary

  Fix TensorIndependent shape calculation bug and improve TensorTanhNormal properties

  Problem:
  - When reinterpreted_batch_ndims=0, the TensorIndependent shape calculation base_distribution.shape[:-0]
  incorrectly returned an empty torch.Size([]) instead of preserving the full base distribution shape
  - TensorTanhNormal had a confusing reinterpreted_batch_ndims parameter that should be handled by wrapping with
  TensorIndependent instead
  - TensorTanhNormal was missing statistical properties like mean, variance, and stddev
  - SamplingDistribution needed improvements for better caching and error handling

  Solutions:

  1. TensorIndependent Shape Bug Fix

  - Fixed shape calculation in TensorIndependent.__init__() to handle reinterpreted_batch_ndims=0 correctly
  - Changed from: Size(base_distribution.shape[:-reinterpreted_batch_ndims])
  - Changed to: Size(base_distribution.shape[:-reinterpreted_batch_ndims] if reinterpreted_batch_ndims > 0 else 
  base_distribution.shape)


  2. TensorTanhNormal Simplification

  - Removed reinterpreted_batch_ndims parameter - users should now use TensorIndependent wrapper for this
  functionality
  - Added comprehensive docstring explaining usage and relationship with TensorIndependent
  - Added statistical properties (mean, variance, stddev) computed via sampling
  - Added log_prob method for direct probability computation

  3. SamplingDistribution Enhancements

  - Added comprehensive docstring and type hints
  - Implemented __slots__ for memory efficiency
  - Added input validation for constructor parameters
  - Improved mode calculation with fallback to analytical mode when available
  - Added cached properties for efficient repeated access to statistics
  - Enhanced error handling and numerical stability
  - Added support and arg_constraints properties

  Files Changed:

  1. src/tensorcontainer/tensor_distribution/independent.py:
    - Fixed shape calculation logic in constructor
  2. src/tensorcontainer/tensor_distribution/tanh_normal.py:
    - Removed reinterpreted_batch_ndims parameter and related logic
    - Added statistical properties using SamplingDistribution
    - Added comprehensive documentation
    - Added log_prob method
  3. src/tensorcontainer/distributions/sampling.py:
    - Complete rewrite with proper caching, validation, and documentation
    - Added __slots__ for memory efficiency
    - Improved statistical calculations with better numerical stability
    - Enhanced mode calculation with analytical fallback
  4. tests/tensor_distribution/test_independent.py:
    - Enhanced test_broadcasting_shapes to verify both batch_shape and shape properties
    - Consolidated testing by removing duplicate test class
  5. tests/tensor_distribution/test_tanh_normal.py & tests/tensor_distribution/test_sampling.py:
    - Updated tests to match API changes

  Testing:
  - All existing tests pass
  - Enhanced test coverage for shape properties in TensorIndependent
  - Tests validate the new statistical properties in TensorTanhNormal

  Impact:
  - Breaking Change: TensorTanhNormal no longer accepts reinterpreted_batch_ndims parameter
  - Fixes critical shape calculation bug in TensorIndependent
  - Improves usability with proper statistical properties in TensorTanhNormal
  - Better performance and reliability in SamplingDistribution
  - Maintains clear separation of concerns between distribution types and batch dimension handling

  Migration Guide:
  # Old usage:
  tanh_normal = TensorTanhNormal(loc, scale, reinterpreted_batch_ndims=1)

  # New usage:
  from tensorcontainer.tensor_distribution import TensorIndependent
  tanh_normal = TensorIndependent(
      TensorTanhNormal(loc, scale),
      reinterpreted_batch_ndims=1
  )