### PR TITLE
refactor(tanh_normal): Consolidate distribution and property handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tensorcontainer"
-version = "0.6.2"
+version = "0.6.3"
 description = "TensorDict-like functionality for PyTorch with PyTree compatibility and torch.compile support"
 authors = [{name="Tim Joseph", email="tim@mctigger.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
The TensorTanhNormal class has been refactored to consistently use SamplingDistribution for its primary distribution and cached sampling properties.

- The `dist()` method now returns a `SamplingDistribution` wrapping the `TransformedDistribution`.
- The `log_prob` method was removed from `TensorTanhNormal`, as log probabilities are now expected to be accessed via the underlying distribution.
- The `_sampling_dist` property is now directly initialized with the `TransformedDistribution` for improved consistency and to avoid circular references.
- Docstrings for `mean`, `variance`, and `stddev` were updated to reflect their consistent computation via sampling.