### PR TITLE
Modernize type hints to PEP 604 and collections.abc

### DIFF
--- a/src/tensorcontainer/tensor_annotated.py
+++ b/src/tensorcontainer/tensor_annotated.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable, TypeVar, Union, get_args
+from typing import Any, TypeVar, Union, get_args
+from collections.abc import Iterable
 
 from torch import Tensor
 from torch.utils import _pytree as pytree

--- a/src/tensorcontainer/tensor_dataclass.py
+++ b/src/tensorcontainer/tensor_dataclass.py
@@ -297,7 +297,7 @@ class TensorDataClass(TensorAnnotated, TensorDataclassTransform):
         return new_obj
 
     def __deepcopy__(
-        self: T_TensorDataclass, memo: Optional[dict] = None
+        self: T_TensorDataclass, memo: dict | None = None
     ) -> T_TensorDataclass:
         """
         Performs a deep copy of the TensorDataclass instance.

--- a/src/tensorcontainer/tensor_distribution/chi2.py
+++ b/src/tensorcontainer/tensor_distribution/chi2.py
@@ -30,7 +30,7 @@ class TensorChi2(TensorDistribution):
         return TorchChi2(df=self._df, validate_args=self._validate_args)
 
     @classmethod
-    def _unflatten_distribution(cls, attributes: dict[str, Any]) -> "TensorChi2":
+    def _unflatten_distribution(cls, attributes: dict[str, Any]) -> TensorChi2:
         return cls(df=attributes["_df"], validate_args=attributes.get("_validate_args"))
 
     @property

--- a/src/tensorcontainer/tensor_distribution/continuous_bernoulli.py
+++ b/src/tensorcontainer/tensor_distribution/continuous_bernoulli.py
@@ -55,7 +55,7 @@ class TensorContinuousBernoulli(TensorDistribution):
     def _unflatten_distribution(
         cls,
         attributes: dict[str, Any],
-    ) -> "TensorContinuousBernoulli":
+    ) -> TensorContinuousBernoulli:
         return cls(
             probs=attributes.get("_probs"),
             logits=attributes.get("_logits"),

--- a/src/tensorcontainer/tensor_distribution/exponential.py
+++ b/src/tensorcontainer/tensor_distribution/exponential.py
@@ -31,7 +31,7 @@ class TensorExponential(TensorDistribution):
     def _unflatten_distribution(
         cls,
         attributes: dict[str, Any],
-    ) -> "TensorExponential":
+    ) -> TensorExponential:
         return cls(
             rate=attributes["_rate"], validate_args=attributes.get("_validate_args")
         )

--- a/src/tensorcontainer/tensor_distribution/kumaraswamy.py
+++ b/src/tensorcontainer/tensor_distribution/kumaraswamy.py
@@ -35,7 +35,7 @@ class TensorKumaraswamy(TensorDistribution):
     def _unflatten_distribution(
         cls,
         attributes: dict[str, Any],
-    ) -> "TensorKumaraswamy":
+    ) -> TensorKumaraswamy:
         """Reconstruct distribution from tensor attributes."""
         return cls(
             concentration1=attributes["_concentration1"],

--- a/src/tensorcontainer/tensor_distribution/relaxed_bernoulli.py
+++ b/src/tensorcontainer/tensor_distribution/relaxed_bernoulli.py
@@ -48,7 +48,7 @@ class TensorRelaxedBernoulli(TensorDistribution):
     @classmethod
     def _unflatten_distribution(
         cls, attributes: dict[str, Any]
-    ) -> "TensorRelaxedBernoulli":
+    ) -> TensorRelaxedBernoulli:
         """Reconstruct distribution from tensor attributes."""
         return cls(
             temperature=attributes["_temperature"],

--- a/src/tensorcontainer/tensor_distribution/relaxed_one_hot_categorical.py
+++ b/src/tensorcontainer/tensor_distribution/relaxed_one_hot_categorical.py
@@ -50,7 +50,7 @@ class TensorRelaxedOneHotCategorical(TensorDistribution):
     def _unflatten_distribution(
         cls,
         attributes: dict[str, Any],
-    ) -> "TensorRelaxedOneHotCategorical":
+    ) -> TensorRelaxedOneHotCategorical:
         """Reconstruct distribution from tensor attributes."""
         return cls(
             temperature=attributes["_temperature"][0],

--- a/src/tensorcontainer/tensor_distribution/student_t.py
+++ b/src/tensorcontainer/tensor_distribution/student_t.py
@@ -47,7 +47,7 @@ class TensorStudentT(TensorDistribution):
     def _unflatten_distribution(
         cls,
         attributes: dict[str, Any],
-    ) -> "TensorStudentT":
+    ) -> TensorStudentT:
         return cls(
             df=attributes["_df"],
             loc=attributes["_loc"],

--- a/src/tensorcontainer/utils.py
+++ b/src/tensorcontainer/utils.py
@@ -6,13 +6,9 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Iterable,
-    Iterator,
-    List,
-    Tuple,
-    Type,
     TypeVar,
 )
+from collections.abc import Iterable, Iterator
 
 import torch
 import torch.utils._pytree as pytree
@@ -72,7 +68,7 @@ class PytreeRegistered:
         )
 
     @abstractmethod
-    def _pytree_flatten(self) -> Tuple[List[Any], Context]:
+    def _pytree_flatten(self) -> tuple[list[Any], Context]:
         """Flattens the instance into leaves and context for PyTree operations.
 
         Subclasses must implement this to define how their structure is decomposed
@@ -87,7 +83,7 @@ class PytreeRegistered:
     @abstractmethod
     def _pytree_flatten_with_keys_fn(
         self,
-    ) -> Tuple[List[Tuple[KeyEntry, Any]], Any]:
+    ) -> tuple[list[tuple[KeyEntry, Any]], Any]:
         """Flattens the instance with keys for advanced PyTree traversal.
 
         Similar to _pytree_flatten, but includes key information for each leaf,
@@ -102,7 +98,7 @@ class PytreeRegistered:
     @classmethod
     @abstractmethod
     def _pytree_unflatten(
-        cls: Type[_PytreeRegistered], leaves: Iterable[Any], context: Context
+        cls: type[_PytreeRegistered], leaves: Iterable[Any], context: Context
     ) -> PyTree:
         """Reconstructs an instance from flattened leaves and context.
 
@@ -176,7 +172,7 @@ class StructureMismatch:
 class KeyPathMismatch(StructureMismatch):
     """Represents a mismatch in key paths between PyTrees."""
 
-    keypaths: Tuple[KeyPath, ...]
+    keypaths: tuple[KeyPath, ...]
 
     def __str__(self) -> str:
         # Format each keypath for better readability
@@ -301,7 +297,7 @@ def diagnose_pytree_structure_mismatch(
     """
 
     def diagnose_keypaths_equal(
-        keypaths: Tuple[KeyPath, ...],
+        keypaths: tuple[KeyPath, ...],
     ) -> KeyPathMismatch | None:
         """Check if all key paths are equal.
 
@@ -315,7 +311,7 @@ def diagnose_pytree_structure_mismatch(
             return KeyPathMismatch(keypaths=keypaths)
 
     def diagnose_types_equal(
-        node_types: Tuple[type, ...], key_path: KeyPath = ()
+        node_types: tuple[type, ...], key_path: KeyPath = ()
     ) -> TypeMismatch | None:
         """Check if all node types are equal to the first type.
 
@@ -336,7 +332,7 @@ def diagnose_pytree_structure_mismatch(
                 )
 
     def diagnose_contexts_equal(
-        contexts: Tuple[Context, ...], key_path: KeyPath = ()
+        contexts: tuple[Context, ...], key_path: KeyPath = ()
     ) -> ContextMismatch | None:
         """Check if all contexts are equal.
 
@@ -360,7 +356,7 @@ def diagnose_pytree_structure_mismatch(
         key_path: KeyPath,
         tree: PyTree,
         is_leaf: Callable[[PyTree], bool] | None = None,
-    ) -> Iterator[Tuple[KeyPath, type, Context]]:
+    ) -> Iterator[tuple[KeyPath, type, Context]]:
         """Recursively traverse a PyTree, yielding key paths, node types, and contexts.
 
         This function performs a depth-first traversal of the PyTree structure,

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -1,4 +1,7 @@
-from typing import Any, Iterable, Type
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import Iterable
 
 import torch
 
@@ -45,8 +48,8 @@ class StubTensorContainer(TensorContainer):
 
     @classmethod
     def _pytree_unflatten(
-        cls: Type["StubTensorContainer"], leaves: Iterable[Any], context: Any
-    ) -> "StubTensorContainer":
+        cls: type[StubTensorContainer], leaves: Iterable[Any], context: Any
+    ) -> StubTensorContainer:
         """Reconstruct from flattened tensors and context."""
         if not cls._in_context:
             raise RuntimeError(

--- a/tests/tensor_dataclass/conftest.py
+++ b/tests/tensor_dataclass/conftest.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import dataclasses
-from typing import List, Optional
 
 import pytest
 import torch
@@ -37,10 +38,10 @@ class OptionalFieldsTestClass(TensorDataClass):
     """TensorDataclass with optional and default_factory fields for testing."""
 
     obs: torch.Tensor
-    reward: Optional[torch.Tensor]
-    info: List[str] = dataclasses.field(default_factory=list)
-    optional_meta: Optional[str] = None
-    optional_meta_val: Optional[str] = "value"
+    reward: torch.Tensor | None
+    info: list[str] = dataclasses.field(default_factory=list)
+    optional_meta: str | None = None
+    optional_meta_val: str | None = "value"
     default_tensor: torch.Tensor = dataclasses.field(
         default_factory=lambda: torch.zeros(4)
     )
@@ -431,8 +432,8 @@ class NestedTensorDataClass(TensorDataClass):
     tensor: torch.Tensor
     tensor_data_class: FlatTensorDataClass
     meta_data: str
-    optional_tensor: Optional[torch.Tensor] = None
-    optional_meta_data: Optional[str] = None
+    optional_tensor: torch.Tensor | None = None
+    optional_meta_data: str | None = None
 
 
 # ============================================================================

--- a/tests/tensor_dataclass/test_stack.py
+++ b/tests/tensor_dataclass/test_stack.py
@@ -6,7 +6,9 @@ including handling of different dimensions, shapes, metadata, optional fields,
 and edge cases.
 """
 
-from typing import Any, List, Optional, cast
+from __future__ import annotations
+
+from typing import Any, cast
 
 import pytest
 import torch
@@ -71,7 +73,7 @@ class TestStackGeneral:
         assert stacked_td.meta_data == td1.meta_data
 
         normalized_dim = dim if dim >= 0 else dim + len(original_batch_shape) + 1
-        slicer: List[Any] = [slice(None)] * len(expected_tensor_shape)
+        slicer: list[Any] = [slice(None)] * len(expected_tensor_shape)
 
         slicer[normalized_dim] = 0
         testing.assert_close(stacked_td.tensor[tuple(slicer)], td1.tensor)
@@ -203,7 +205,7 @@ class TestStackOptionalFields:
 
         class OptionalStack(TensorDataClass):
             a: torch.Tensor
-            b: Optional[torch.Tensor] = None
+            b: torch.Tensor | None = None
 
         td1 = OptionalStack(
             shape=(3,), device=torch.device("cpu"), a=torch.randn(3), b=torch.ones(3)

--- a/tests/tensor_distribution/conftest.py
+++ b/tests/tensor_distribution/conftest.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import inspect
-from typing import Type
 
 import pytest
 import torch
@@ -163,7 +164,7 @@ def normalize_device(dev: torch.device) -> torch.device:
 
 
 def assert_init_signatures_match(
-    td_class: Type[TensorDistribution], torch_dist_class: Type[Distribution]
+    td_class: type[TensorDistribution], torch_dist_class: type[Distribution]
 ) -> None:
     """
     Assert that __init__ signatures match between TensorDistribution and Distribution.
@@ -216,7 +217,7 @@ def assert_init_signatures_match(
 
 
 def _get_torch_dist_properties(
-    torch_dist_class: Type[Distribution],
+    torch_dist_class: type[Distribution],
 ) -> list[tuple[str, property]]:
     """
     Discover relevant public properties from a torch.distribution.Distribution class.
@@ -257,7 +258,7 @@ def _get_torch_dist_properties(
 
 
 def assert_properties_signatures_match(
-    td_class: Type[TensorDistribution], torch_dist_class: Type[Distribution]
+    td_class: type[TensorDistribution], torch_dist_class: type[Distribution]
 ) -> None:
     """
     Asserts that public properties of a torch.distribution.Distribution are mirrored


### PR DESCRIPTION
Update type hint syntax across the codebase for improved readability and consistency.

Key changes include:
- Adopted PEP 604 union syntax (`X | Y` and `X | None`) replacing `typing.Union` and `typing.Optional`.
- Switched to built-in `list` and `tuple` for type hints, and imported `Iterable` and `Mapping` from `collections.abc`.
- Replaced `typing.Type[X]` with `type[X]` for type objects.
- Removed string literal forward references due to `from __future__ import annotations`.